### PR TITLE
feat(web): refine layout and footer

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer style={{ background: "#0f172a", color: "#fff", marginTop: 40 }}>
+      <div style={{ maxWidth: 1200, margin: "0 auto", padding: "40px 16px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", flexWrap: "wrap", gap: 24 }}>
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 8 }}>
+            <li><Link href="#" style={{ color: "#cbd5e1", textDecoration: "none" }}>Адреса и зоны доставки</Link></li>
+            <li><Link href="#" style={{ color: "#cbd5e1", textDecoration: "none" }}>Отзывы</Link></li>
+            <li><Link href="#" style={{ color: "#cbd5e1", textDecoration: "none" }}>Акции</Link></li>
+            <li><Link href="#" style={{ color: "#cbd5e1", textDecoration: "none" }}>Доставка и оплата</Link></li>
+            <li><Link href="#" style={{ color: "#cbd5e1", textDecoration: "none" }}>Бонусная программа</Link></li>
+            <li><Link href="#" style={{ color: "#cbd5e1", textDecoration: "none" }}>Вакансии</Link></li>
+          </ul>
+          <div style={{ textAlign: "right" }}>
+            <p style={{ margin: 0, marginBottom: 8 }}>Акции, которые нельзя есть, — в наших приложениях!</p>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <a href="#" style={{ background: "#fff", color: "#000", padding: "6px 12px", borderRadius: 8, textDecoration: "none", fontSize: 12 }}>App Store</a>
+              <a href="#" style={{ background: "#fff", color: "#000", padding: "6px 12px", borderRadius: 8, textDecoration: "none", fontSize: 12 }}>Google Play</a>
+            </div>
+          </div>
+        </div>
+        <div style={{ marginTop: 32, fontSize: 12, color: "#94a3b8", display: "flex", flexWrap: "wrap", gap: 16 }}>
+          <span>ИП Таубекова Б.К.</span>
+          <Link href="#" style={{ color: "#94a3b8", textDecoration: "none" }}>Политика конфиденциальности</Link>
+          <Link href="#" style={{ color: "#94a3b8", textDecoration: "none" }}>Публичная оферта</Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 export default function Header() {
     const [q, setQ] = useState("");
+    const cartAmount = 0;
 
     return (
         <header style={{
@@ -55,9 +56,25 @@ export default function Header() {
                     </Link>
                     <Link href="/checkout" style={{
                         background: "#ef4444", color: "#fff", textDecoration: "none",
-                        padding: "8px 12px", borderRadius: 10, fontWeight: 700
+                        padding: "8px 12px", borderRadius: 10, fontWeight: 700,
+                        display: "inline-flex", alignItems: "center", gap: 8
                     }}>
-                        0 ₸
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="24"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <circle cx="9" cy="21" r="1" />
+                            <circle cx="20" cy="21" r="1" />
+                            <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" />
+                        </svg>
+                        {cartAmount > 0 && <span>{cartAmount} ₸</span>}
                     </Link>
                 </nav>
             </div>

--- a/apps/web/src/components/MainMenu.tsx
+++ b/apps/web/src/components/MainMenu.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+const items = [
+  { title: "Комбо", href: "#Комбо" },
+  { title: "Блюда", href: "#Блюда" },
+  { title: "Закуски", href: "#Закуски" },
+  { title: "Соусы", href: "#Соусы" },
+  { title: "Напитки", href: "#Напитки" },
+];
+
+export default function MainMenu() {
+  return (
+    <aside
+      style={{
+        width: 220,
+        padding: 20,
+        borderRight: "1px solid #eee",
+        position: "sticky",
+        top: 70,
+        alignSelf: "flex-start",
+      }}
+    >
+      <nav>
+        <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 12 }}>
+          {items.map((item) => (
+            <li key={item.title}>
+              <a href={item.href} className="sidebar-link">
+                {item.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/apps/web/src/components/PromoSlider.tsx
+++ b/apps/web/src/components/PromoSlider.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from "react";
+
+const slides = [
+  "https://via.placeholder.com/600x200?text=Promo+1",
+  "https://via.placeholder.com/600x200?text=Promo+2",
+  "https://via.placeholder.com/600x200?text=Promo+3",
+];
+
+export default function PromoSlider() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setIndex((i) => (i + 1) % slides.length), 3000);
+    return () => clearInterval(id);
+  }, []);
+
+  const prev = () => setIndex((i) => (i - 1 + slides.length) % slides.length);
+  const next = () => setIndex((i) => (i + 1) % slides.length);
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        width: "100%",
+        height: "200px",
+        marginBottom: "20px",
+        borderRadius: "8px",
+      }}
+    >
+      {slides.map((src, i) => (
+        <img
+          key={i}
+          src={src}
+          alt={`Promo ${i + 1}`}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: `${(i - index) * 100}%`,
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            transition: "left 0.5s ease-in-out",
+          }}
+        />
+      ))}
+      <button
+        onClick={prev}
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "10px",
+          transform: "translateY(-50%)",
+          background: "rgba(0,0,0,0.5)",
+          color: "#fff",
+          border: "none",
+          borderRadius: "50%",
+          width: "30px",
+          height: "30px",
+          cursor: "pointer",
+        }}
+      >
+        ‹
+      </button>
+      <button
+        onClick={next}
+        style={{
+          position: "absolute",
+          top: "50%",
+          right: "10px",
+          transform: "translateY(-50%)",
+          background: "rgba(0,0,0,0.5)",
+          color: "#fff",
+          border: "none",
+          borderRadius: "50%",
+          width: "30px",
+          height: "30px",
+          cursor: "pointer",
+        }}
+      >
+        ›
+      </button>
+    </div>
+  );
+}
+

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from "next/app";
+import "../styles/globals.css";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/apps/web/src/pages/category/[slug].tsx
+++ b/apps/web/src/pages/category/[slug].tsx
@@ -1,6 +1,12 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import type { DishDTO } from "@appetit/shared";
+type DishDTO = {
+  id: string;
+  name: string;
+  imageUrl?: string;
+  minPrice?: number;
+  basePrice: number;
+};
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
 

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import Header from "../components/Header";
+import MainMenu from "../components/MainMenu";
+import Footer from "../components/Footer";
+import PromoSlider from "../components/PromoSlider";
 
 const categories = [
   {
@@ -19,45 +22,95 @@ const categories = [
       { title: "Классическая Большая шаурма", price: "2490 ₸", img: "/images/sh4.png" },
     ],
   },
+  {
+    name: "Закуски",
+    items: [
+      { title: "Шекер", price: "400 ₸", img: "https://placehold.co/200x200" },
+      { title: "Чебуреки", price: "240 ₸", img: "https://placehold.co/200x200" },
+      { title: "Наггетсы", price: "от 1490 ₸", img: "https://placehold.co/200x200" },
+      { title: "Фри", price: "от 790 ₸", img: "https://placehold.co/200x200" },
+      { title: "Долма", price: "от 1190 ₸", img: "https://placehold.co/200x200" },
+    ],
+  },
+  {
+    name: "Соусы",
+    items: [
+      { title: "Перечный острый 15г", price: "240 ₸", img: "https://placehold.co/200x200" },
+      { title: "Соус Сырный 30г", price: "240 ₸", img: "https://placehold.co/200x200" },
+      { title: "Соус Томатный 30г", price: "240 ₸", img: "https://placehold.co/200x200" },
+      { title: "Соус Горчичный 30г", price: "240 ₸", img: "https://placehold.co/200x200" },
+      { title: "Соус Барбекю 30г", price: "240 ₸", img: "https://placehold.co/200x200" },
+      { title: "Соус Чесночный 30г", price: "240 ₸", img: "https://placehold.co/200x200" },
+      { title: "Соус Острый 30г", price: "240 ₸", img: "https://placehold.co/200x200" },
+    ],
+  },
+  {
+    name: "Напитки",
+    items: [
+      { title: "Сок Лимонный 1л", price: "990 ₸", img: "https://placehold.co/200x200" },
+      { title: "Сок Виноградный 1л", price: "990 ₸", img: "https://placehold.co/200x200" },
+      { title: "Морс Смородина 1л", price: "990 ₸", img: "https://placehold.co/200x200" },
+      { title: "Айран 1ст", price: "990 ₸", img: "https://placehold.co/200x200" },
+      { title: "Пепси 1л", price: "640 ₸", img: "https://placehold.co/200x200" },
+      { title: "Пепси 0.5л", price: "490 ₸", img: "https://placehold.co/200x200" },
+      { title: "Чай 0.5л", price: "390 ₸", img: "https://placehold.co/200x200" },
+      { title: "Дюшес 0.5л", price: "390 ₸", img: "https://placehold.co/200x200" },
+      { title: "Бонаква 0.5л", price: "260 ₸", img: "https://placehold.co/200x200" },
+      { title: "Аква 1л", price: "370 ₸", img: "https://placehold.co/200x200" },
+    ],
+  },
 ];
 
 export default function Home() {
   return (
-    <div style={{ display: "flex", fontFamily: "Arial, sans-serif" }}>
-      {/* Сайдбар */}
-      <aside style={{ width: "220px", padding: "20px", borderRight: "1px solid #eee" }}>
-        <h3>Категории</h3>
-        <ul style={{ listStyle: "none", padding: 0 }}>
+    <>
+      <Header />
+      <div style={{ maxWidth: 1200, margin: "0 auto", display: "flex" }}>
+        <MainMenu />
+        <main style={{ flex: 1, padding: "20px" }}>
+          <PromoSlider />
           {categories.map((cat) => (
-            <li key={cat.name} style={{ margin: "10px 0" }}>
-              <a href={`#${cat.name}`} style={{ textDecoration: "none", color: "#333" }}>
-                {cat.name}
-              </a>
-            </li>
+            <section key={cat.name} id={cat.name} style={{ marginBottom: "40px" }}>
+              <h2 style={{ marginBottom: "20px" }}>{cat.name}</h2>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+                  gap: "20px",
+                }}
+              >
+                {cat.items.map((item) => (
+                  <div
+                    key={item.title}
+                    style={{ border: "1px solid #eee", borderRadius: "8px", padding: "15px" }}
+                  >
+                    <img
+                      src={item.img}
+                      alt={item.title}
+                      style={{ width: "100%", borderRadius: "8px" }}
+                    />
+                    <h4 style={{ margin: "10px 0" }}>{item.title}</h4>
+                    <p style={{ color: "#666", fontSize: "14px" }}>{item.price}</p>
+                    <button
+                      style={{
+                        background: "#e31b23",
+                        color: "#fff",
+                        border: "none",
+                        padding: "10px",
+                        borderRadius: "5px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      Добавить
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </section>
           ))}
-        </ul>
-      </aside>
-
-      {/* Контент */}
-      <main style={{ flex: 1, padding: "20px" }}>
-        {categories.map((cat) => (
-          <section key={cat.name} id={cat.name} style={{ marginBottom: "40px" }}>
-            <h2 style={{ marginBottom: "20px" }}>{cat.name}</h2>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: "20px" }}>
-              {cat.items.map((item) => (
-                <div key={item.title} style={{ border: "1px solid #eee", borderRadius: "8px", padding: "15px" }}>
-                  <img src={item.img} alt={item.title} style={{ width: "100%", borderRadius: "8px" }} />
-                  <h4 style={{ margin: "10px 0" }}>{item.title}</h4>
-                  <p style={{ color: "#666", fontSize: "14px" }}>{item.price}</p>
-                  <button style={{ background: "#e31b23", color: "#fff", border: "none", padding: "10px", borderRadius: "5px", cursor: "pointer" }}>
-                    Добавить
-                  </button>
-                </div>
-              ))}
-            </div>
-          </section>
-        ))}
-      </main>
-    </div>
+        </main>
+      </div>
+      <Footer />
+    </>
   );
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,0 +1,18 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+.sidebar-link {
+  display: block;
+  padding: 8px 12px;
+  border-radius: 6px;
+  text-decoration: none;
+  color: #333;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.sidebar-link:hover {
+  background: #f3f4f6;
+  color: #e31b23;
+}


### PR DESCRIPTION
## Summary
- center main page content and load global CSS
- add sidebar hover styles and new footer links
- display promotional slider above menu categories
- scaffold additional sections for snacks, sauces and drinks

## Testing
- `pnpm --filter @appetit/web build`


------
https://chatgpt.com/codex/tasks/task_e_68a6c2a80e208325b3dc6d8bedb8f1ba