### PR TITLE
feat(web): add placeholder pages and footer links

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+export default function Footer() {
+    return (
+        <footer style={{
+            background: "#0f172a",
+            color: "#fff",
+            borderTop: "1px solid #0b1226",
+            padding: "20px 0",
+            marginTop: 40
+        }}>
+            <div style={{
+                maxWidth: 1200,
+                margin: "0 auto",
+                padding: "0 16px",
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 16
+            }}>
+                <Link href="/addresses" style={{ color: "#cbd5e1", textDecoration: "none" }}>Адреса</Link>
+                <Link href="/reviews" style={{ color: "#cbd5e1", textDecoration: "none" }}>Отзывы</Link>
+                <Link href="/promotions" style={{ color: "#cbd5e1", textDecoration: "none" }}>Акции</Link>
+                <Link href="/delivery-payment" style={{ color: "#cbd5e1", textDecoration: "none" }}>Доставка и оплата</Link>
+                <Link href="/bonus-program" style={{ color: "#cbd5e1", textDecoration: "none" }}>Бонусная программа</Link>
+                <Link href="/careers" style={{ color: "#cbd5e1", textDecoration: "none" }}>Карьера</Link>
+            </div>
+        </footer>
+    );
+}

--- a/apps/web/src/pages/addresses.tsx
+++ b/apps/web/src/pages/addresses.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+export default function Addresses() {
+    return (
+        <>
+            <Header />
+            <main style={{ maxWidth: 1200, margin: "20px auto", padding: "0 16px" }}>
+                <h1>Адреса</h1>
+                <p>Здесь будет список адресов наших ресторанов.</p>
+            </main>
+            <Footer />
+        </>
+    );
+}

--- a/apps/web/src/pages/bonus-program.tsx
+++ b/apps/web/src/pages/bonus-program.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+export default function BonusProgram() {
+    return (
+        <>
+            <Header />
+            <main style={{ maxWidth: 1200, margin: "20px auto", padding: "0 16px" }}>
+                <h1>Бонусная программа</h1>
+                <p>Скоро здесь появится информация о бонусной программе.</p>
+            </main>
+            <Footer />
+        </>
+    );
+}

--- a/apps/web/src/pages/careers.tsx
+++ b/apps/web/src/pages/careers.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+export default function Careers() {
+    return (
+        <>
+            <Header />
+            <main style={{ maxWidth: 1200, margin: "20px auto", padding: "0 16px" }}>
+                <h1>Карьера</h1>
+                <p>Информация о текущих вакансиях будет опубликована здесь.</p>
+            </main>
+            <Footer />
+        </>
+    );
+}

--- a/apps/web/src/pages/delivery-payment.tsx
+++ b/apps/web/src/pages/delivery-payment.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+export default function DeliveryPayment() {
+    return (
+        <>
+            <Header />
+            <main style={{ maxWidth: 1200, margin: "20px auto", padding: "0 16px" }}>
+                <h1>Доставка и оплата</h1>
+                <p>Информация о способах доставки и вариантах оплаты появится здесь.</p>
+            </main>
+            <Footer />
+        </>
+    );
+}

--- a/apps/web/src/pages/promotions.tsx
+++ b/apps/web/src/pages/promotions.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+export default function Promotions() {
+    return (
+        <>
+            <Header />
+            <main style={{ maxWidth: 1200, margin: "20px auto", padding: "0 16px" }}>
+                <h1>Акции</h1>
+                <p>Здесь будут действующие акции и спецпредложения.</p>
+            </main>
+            <Footer />
+        </>
+    );
+}

--- a/apps/web/src/pages/reviews.tsx
+++ b/apps/web/src/pages/reviews.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+export default function Reviews() {
+    return (
+        <>
+            <Header />
+            <main style={{ maxWidth: 1200, margin: "20px auto", padding: "0 16px" }}>
+                <h1>Отзывы</h1>
+                <p>Здесь будут отзывы наших клиентов.</p>
+            </main>
+            <Footer />
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
- add placeholder pages: addresses, reviews, promotions, delivery-payment, bonus-program, careers
- implement footer with links to new pages

## Testing
- `corepack pnpm -C apps/web build` *(fails: Cannot find module '@appetit/shared')*

------
https://chatgpt.com/codex/tasks/task_e_68a6fbfbf6788325ae116287ffc0936e